### PR TITLE
Increase check timeout to 1m30s

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "web": [
       {
         "type": "startup",
-        "path": "/",
+        "path": "/if/flow/default-authentication-flow/",
         "initialDelay": 90,
         "attempts": 3
       }

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
       {
         "type": "startup",
         "path": "/",
-        "initialDelay": 5,
+        "initialDelay": 90,
         "attempts": 3
       }
     ]


### PR DESCRIPTION
I measured 1 minute to boot the web server just now, so do that +30s grace period.

Fixes SeaGL/seagl-ansible#182