### PR TITLE
Bump to Authentik 24.8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/goauthentik/server:2024.2.2
+FROM ghcr.io/goauthentik/server:2024.8.6
 
 # TODO Procfile apparently doesn't need to be copied. Does app.json?
 COPY app.json .


### PR DESCRIPTION
I read all the intervening changelogs. There are breaking changes, but none that apply to us.

This isn't the absolute latest version because it's a bad idea to deploy a large number of changes at once. Makes rollback and diagnosis harder.