### PR TITLE
Bump to Authentik 2025.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/goauthentik/server:2024.8.6
+FROM ghcr.io/goauthentik/server:2025.2.3
 
 # TODO Procfile apparently doesn't need to be copied. Does app.json?
 COPY app.json .


### PR DESCRIPTION
There are breaking changes, but none that apply to us. I read all intervening changelogs.

This bumps Authentik to the latest upstream release.