### PR TITLE
Bump to Authentik 2025.10.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/goauthentik/server:2025.8.4
+FROM ghcr.io/goauthentik/server:2025.10.3
 
 # TODO Procfile apparently doesn't need to be copied. Does app.json?
 COPY app.json .


### PR DESCRIPTION
I've read [the changelog](https://docs.goauthentik.io/releases/2025.10/#new-integration-guides) and we are good to deploy this. I'm only PR'ing instead of committing directly because of this GitHub Actions incident: https://www.githubstatus.com/incidents/xwn6hjps36ty